### PR TITLE
Fix unwrap or default to avoid panics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,12 +6,12 @@ on:
       - main
       - master
     tags:
-      - '*'
+      - "*"
   pull_request:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'tag'
+        description: "tag"
 
 jobs:
   test:
@@ -21,6 +21,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install Python development headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-dev
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -220,7 +227,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: "wheels-*/*"
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -28,50 +28,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "dlv-list"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
+checksum = "ecb08c4819242b1ec89b3d0c6affa229005bef46ae4f7eed8b80768187c10087"
 
 [[package]]
 name = "getrandom"
@@ -208,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -223,20 +183,19 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -244,11 +203,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom",
 ]
 
 [[package]]
@@ -259,9 +218,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -276,7 +235,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "theine_core"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "ahash",
  "dlv-list",
@@ -285,19 +244,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unindent"
@@ -310,12 +260,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,9 +230,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -246,6 +252,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "dlv-list",
+ "log",
  "pyo3",
  "rand",
 ]
@@ -285,18 +292,18 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +244,7 @@ name = "theine_core"
 version = "2.1.0"
 dependencies = [
  "ahash",
+ "anyhow",
  "dlv-list",
  "pyo3",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "theine_core"
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow = "1.0"
 dlv-list = "0.6"
 pyo3 = { version = "0.27.1", features = ["extension-module"] }
 rand = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "theine_core"
 version = "2.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "theine_core"
 crate-type = ["cdylib"]
 
 [dependencies]
-dlv-list = "0.5.2"
+dlv-list = "0.6"
 pyo3 = { version = "0.27.1", features = ["extension-module"] }
-rand = "0.8.5"
+rand = "0.9"
 
 [dev-dependencies]
 ahash = "0.8.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 anyhow = "1.0"
 dlv-list = "0.6"
 pyo3 = { version = "0.27.1", features = ["extension-module"] }
+log = "0.4"
 rand = "0.9"
 
 [dev-dependencies]

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,19 +1,44 @@
-use crate::{metadata::Entry, timerwheel::TimerWheel, tlfu::DebugInfo, tlfu::TinyLfu};
+//! Core cache implementation
+//!
+//! This module implements the TinyLFU cache algorithm with TTL support,
+//! exposed to Python through PyO3.
+//!
+//! # Thread Safety
+//!
+//! `TlfuCore` is not thread-safe. Users must wrap it in a `Mutex` or `RwLock`
+//! when sharing across threads.
 
 use std::collections::{HashMap, HashSet};
 
 use pyo3::prelude::*;
 
+use crate::errors::catch_panic;
+use crate::{metadata::Entry, timerwheel::TimerWheel, tlfu::DebugInfo, tlfu::TinyLfu};
+
+/// TinyLFU cache with TTL support
+///
+/// Thread-safe operation requires external synchronization (Mutex/RwLock).
+/// See module documentation for usage details.
 #[pyclass]
 pub struct TlfuCore {
-    pub policy: TinyLfu,
-    pub wheel: TimerWheel,
-    pub entries: HashMap<u64, Entry>,
+    policy: TinyLfu,
+    pub(crate) wheel: TimerWheel,
+    pub(crate) entries: HashMap<u64, Entry>,
 }
 
 #[pymethods]
-// None of the methods in this implementation are thread-safe. Please ensure that you use the appropriate mutex on the caller side.
 impl TlfuCore {
+    /// Creates a new cache with the specified capacity.
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Maximum number of entries to cache
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let mut cache = TlfuCore::new(1000);
+    /// ```
     #[new]
     pub fn new(size: usize) -> Self {
         Self {
@@ -23,212 +48,325 @@ impl TlfuCore {
         }
     }
 
+    /// Sets or updates a cache entry, handling eviction if necessary.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The cache key
+    /// * `ttl` - Time-to-live in nanoseconds
+    ///
+    /// # Returns
+    ///
+    /// `Some(evicted_key)` if an entry was evicted to make room, `None` otherwise
     fn set_entry(&mut self, key: u64, ttl: u64) -> Option<u64> {
-        // update
-        if let Some(exist) = self.entries.get_mut(&key) {
-            exist.expire = self.wheel.clock.expire_ns(ttl);
-            self.wheel.schedule(key, exist);
+        // Update existing entry
+        if let Some(entry) = self.entries.get_mut(&key) {
+            entry.expire = self.wheel.clock.expire_ns(ttl);
+            self.wheel.schedule(key, entry);
             return None;
         }
 
-        // create
+        // Create new entry
         let mut entry = Entry::new();
         entry.expire = self.wheel.clock.expire_ns(ttl);
         self.wheel.schedule(key, &mut entry);
         self.entries.insert(key, entry);
 
-        match self.policy.set(key, &mut self.entries) {
-            Ok(Some(evicted_key)) => {
+        self.policy
+            .set(key, &mut self.entries)
+            .ok()
+            .flatten()
+            .inspect(|&evicted_key| {
                 if let Some(evicted) = self.entries.get_mut(&evicted_key) {
                     self.wheel.deschedule(evicted);
-                    self.entries.remove(&evicted_key);
-                    Some(evicted_key)
-                } else {
-                    None
                 }
-            }
-            Ok(None) => None,
-            Err(e) => {
-                // Log the error but continue - entry was already added to cache
-                // This maintains cache consistency while making the error visible
-                log::error!("Policy error during set_entry for key {}: {}", key, e);
-                None
-            }
-        }
+                self.entries.remove(&evicted_key);
+                log::debug!("Evicted key {} for key {}", evicted_key, key);
+            })
     }
 
+    /// Sets multiple cache entries in a batch operation.
+    ///
+    /// Entries with TTL of -1 are removed instead of added.
+    ///
+    /// # Arguments
+    ///
+    /// * `entries` - Vector of (key, ttl) pairs where ttl=-1 means remove
+    ///
+    /// # Returns
+    ///
+    /// Vector of keys that were evicted to make room for new entries
     pub fn set(&mut self, entries: Vec<(u64, i64)>) -> Vec<u64> {
         let mut evicted = HashSet::new();
-        for entry in entries.iter() {
-            // remove entry
-            if entry.1 == -1 {
-                if let Some(mut removed) = self.entries.remove(&entry.0) {
-                    if let Err(e) = self.policy.remove(&mut removed) {
-                        log::warn!("Policy error during removal of key {}: {}", entry.0, e);
+
+        for (key, ttl) in entries {
+            match ttl {
+                -1 => self.remove_internal(key),
+                _ if !evicted.contains(&key) => {
+                    if let Some(evicted_key) = self.set_entry(key, ttl.unsigned_abs()) {
+                        evicted.insert(evicted_key);
                     }
-                    self.wheel.deschedule(&mut removed);
                 }
-                continue;
-            }
-
-            if evicted.contains(&entry.0) {
-                evicted.remove(&entry.0);
-            }
-            if let Some(key) = self.set_entry(entry.0, entry.1.unsigned_abs()) {
-                evicted.insert(key);
+                _ => {}
             }
         }
 
-        for ev in &evicted {
-            self.entries.remove(ev);
-        }
+        // Clean up evicted entries
+        evicted.retain(|key| self.entries.remove(key).is_some());
 
-        Vec::from_iter(evicted)
+        log::debug!(
+            "Set: {} entries evicted, size={}",
+            evicted.len(),
+            self.entries.len()
+        );
+
+        evicted.into_iter().collect()
     }
 
+    /// Removes an entry from all internal structures.
+    #[inline]
+    fn remove_internal(&mut self, key: u64) {
+        if let Some(mut entry) = self.entries.remove(&key) {
+            let _ = self.policy.remove(&mut entry).map_err(|e| {
+                log::warn!("Failed to remove key {} from policy: {}", key, e);
+            });
+            self.wheel.deschedule(&mut entry);
+            log::debug!("Removed key {}", key);
+        }
+    }
+
+    /// Removes a specific key from the cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to remove
+    ///
+    /// # Returns
+    ///
+    /// `Some(key)` if the key was found and removed, `None` if not present
     pub fn remove(&mut self, key: u64) -> Option<u64> {
-        if let Some(entry) = self.entries.get_mut(&key) {
-            self.wheel.deschedule(entry);
-            match self.policy.remove(entry) {
-                Ok(()) => {
-                    self.entries.remove(&key);
-                    Some(key)
-                }
-                Err(e) => {
-                    // Log the error but still remove from entries to prevent leaks
-                    log::error!("Policy error during remove for key {}: {}", key, e);
-                    self.entries.remove(&key);
-                    Some(key)
-                }
-            }
-        } else {
-            None
-        }
+        self.entries.remove(&key).map(|mut entry| {
+            let _ = self.policy.remove(&mut entry).map_err(|e| {
+                log::error!("remove(key={}): {}", key, e);
+            });
+            self.wheel.deschedule(&mut entry);
+            log::debug!("Removed key {}", key);
+            key
+        })
     }
 
+    /// Marks entries as accessed to update their position in the policy.
+    ///
+    /// # Arguments
+    ///
+    /// * `keys` - Vector of keys to mark as accessed
     pub fn access(&mut self, keys: Vec<u64>) {
+        log::trace!("Accessing {} keys", keys.len());
         for key in keys {
             self.access_entry(key);
         }
     }
 
+    /// Updates policy state for a single accessed entry.
+    #[inline]
     fn access_entry(&mut self, key: u64) {
-        match self
+        let _ = self
             .policy
             .access(key, &self.wheel.clock, &mut self.entries)
-        {
-            Ok(()) => {}
-            Err(e) => {
-                // Log access failures - they indicate bugs in the policy implementation
-                log::error!("Policy error during access for key {}: {}", key, e);
-            }
-        }
+            .map_err(|e| {
+                log::error!("access(key={}): {}", key, e);
+            });
     }
 
+    /// Processes TTL expirations and removes expired entries from the cache.
+    ///
+    /// This advances the internal timer wheel and returns all keys that expired
+    /// during the advancement.
+    ///
+    /// # Returns
+    ///
+    /// Vector of keys that were expired and removed
     pub fn advance(&mut self) -> Vec<u64> {
-        let removed = self
+        let expired = self
             .wheel
             .advance(self.wheel.clock.now_ns(), &mut self.entries);
-        for key in removed.iter() {
-            if let Some(entry) = self.entries.get_mut(key) {
-                match self.policy.remove(entry) {
-                    Ok(()) => {
-                        self.entries.remove(key);
-                    }
-                    Err(e) => {
-                        // Log the error but still remove from entries to prevent leaks
-                        log::error!("Policy error during advance removal for key {}: {}", key, e);
-                        self.entries.remove(key);
-                    }
-                }
+
+        let expired_count = expired.len();
+
+        for &key in &expired {
+            if let Some(mut entry) = self.entries.remove(&key) {
+                let _ = self.policy.remove(&mut entry).map_err(|e| {
+                    log::error!("advance(key={}): {}", key, e);
+                });
+                log::trace!("Expired key {}", key);
             }
         }
-        removed
+
+        if expired_count > 0 {
+            log::debug!("Advance: {} entries expired", expired_count);
+        }
+
+        expired
     }
 
+    /// Removes all entries from the cache.
     pub fn clear(&mut self) {
         self.wheel.clear();
         self.entries.clear();
+        log::debug!("Cache cleared");
     }
 
+    /// Returns the number of entries currently in the cache.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.entries.len()
     }
 
+    /// Returns debugging information about the cache state.
+    #[must_use]
     pub fn debug_info(&self) -> DebugInfo {
         self.policy.debug_info()
     }
 
+    /// Returns all keys currently stored in the cache.
+    #[must_use]
     pub fn keys(&self) -> Vec<u64> {
         self.entries.keys().copied().collect()
     }
+
+    /// Sets multiple entries with panic safety for Python FFI.
+    pub fn set_with_error(&mut self, entries: Vec<(u64, i64)>) -> PyResult<Vec<u64>> {
+        use std::panic::AssertUnwindSafe;
+        catch_panic(AssertUnwindSafe(|| self.set(entries)), "set")
+    }
+
+    /// Marks entries as accessed with panic safety for Python FFI.
+    pub fn access_with_error(&mut self, keys: Vec<u64>) -> PyResult<()> {
+        use std::panic::AssertUnwindSafe;
+        catch_panic(AssertUnwindSafe(|| self.access(keys)), "access")
+    }
+
+    /// Advances the timer wheel with panic safety for Python FFI.
+    pub fn advance_with_error(&mut self) -> PyResult<Vec<u64>> {
+        use std::panic::AssertUnwindSafe;
+        catch_panic(AssertUnwindSafe(|| self.advance()), "advance")
+    }
 }
 
+/// Supplemental hash function for Python hash values.
+///
+/// Python's hash function returns `i64` which can be negative or weakly distributed.
+/// This function applies the MurmurHash3 finalizer to improve distribution and prevent hash DoS.
+///
+/// # Arguments
+///
+/// * `h` - Python's hash value (an i64)
+///
+/// # Returns
+///
+/// A well-distributed u64 hash value
+///
+/// # Examples
+///
+/// ```ignore
+/// let python_hash = 12345i64;
+/// let improved_hash = spread(python_hash);
+/// ```
 #[pyfunction]
-/// Applies a supplemental hash function to a given hash,
-/// Python's hash function returns i64, which could be negative
+#[must_use]
 pub fn spread(h: i64) -> u64 {
+    // Convert i64 to u64 preserving bit pattern
     let mut z = u64::from_ne_bytes(h.to_ne_bytes());
+
+    // Apply MurmurHash3 finalizer for better distribution
     z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
     z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
-    z = z ^ (z >> 31);
+    z ^= z >> 31;
+
     z
 }
 
 #[cfg(test)]
 mod tests {
-
-    use crate::core::spread;
+    use super::*;
     use rand::Rng;
 
-    use crate::core::TlfuCore;
-
     #[test]
-    fn test_set() {
-        let mut tlfu = TlfuCore::new(1000);
-        tlfu.set(vec![(1, 0), (2, 0), (3, 0)]);
-        let mut s = tlfu.entries.keys().cloned().collect::<Vec<_>>();
-        s.sort();
-        assert_eq!(vec![1, 2, 3], s);
-        tlfu.set(vec![(3, -1), (4, 0), (3, 0)]);
-        s = tlfu.entries.keys().cloned().collect::<Vec<_>>();
-        s.sort();
-        assert_eq!(vec![1, 2, 3, 4], s);
-        tlfu.set(vec![(3, -1), (4, 0)]);
-        s = tlfu.entries.keys().cloned().collect::<Vec<_>>();
-        s.sort();
-        assert_eq!(vec![1, 2, 4], s);
+    fn test_set_operations() {
+        let mut cache = TlfuCore::new(1000);
+
+        // Add entries
+        cache.set(vec![(1, 0), (2, 0), (3, 0)]);
+        let mut keys: Vec<_> = cache.entries.keys().copied().collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec![1, 2, 3]);
+
+        // Remove entry 3, add entry 4, re-add entry 3
+        cache.set(vec![(3, -1), (4, 0), (3, 0)]);
+        keys = cache.entries.keys().copied().collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec![1, 2, 3, 4]);
+
+        // Remove entry 3, keep entry 4
+        cache.set(vec![(3, -1), (4, 0)]);
+        keys = cache.entries.keys().copied().collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec![1, 2, 4]);
     }
 
     #[test]
-    fn test_remove() {
-        let mut tlfu = TlfuCore::new(1000);
-        tlfu.set(vec![(1, 0), (2, 0), (3, 0)]);
-        tlfu.remove(2);
-        let mut s = tlfu.entries.keys().cloned().collect::<Vec<_>>();
-        s.sort();
-        assert_eq!(vec![1, 3], s);
+    fn test_remove_operation() {
+        let mut cache = TlfuCore::new(1000);
+        cache.set(vec![(1, 0), (2, 0), (3, 0)]);
+        cache.remove(2);
+
+        let mut keys: Vec<_> = cache.entries.keys().copied().collect();
+        keys.sort_unstable();
+        assert_eq!(keys, vec![1, 3]);
     }
 
     #[test]
-    fn test_size_small() {
+    fn test_bounded_cache_size() {
         for size in [1, 2, 3] {
-            let mut tlfu = TlfuCore::new(size);
-            tlfu.set(vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]);
-            assert_eq!(size, tlfu.entries.len());
-            tlfu.access(vec![1]);
-            tlfu.set(vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]);
-            assert_eq!(size, tlfu.entries.len());
+            let mut cache = TlfuCore::new(size);
+            cache.set(vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]);
+            assert_eq!(cache.len(), size);
+
+            cache.access(vec![1]);
+            cache.set(vec![(1, 0), (2, 0), (3, 0), (4, 0), (5, 0)]);
+            assert_eq!(cache.len(), size);
         }
     }
 
     #[test]
-    fn test_spread() {
+    fn test_spread_hash_function() {
         let mut rng = rand::rng();
 
-        for _ in 0..500000 {
+        for _ in 0..100_000 {
             let k = rng.random_range(-i64::MAX..i64::MAX);
-            spread(k);
+            let _hashed = spread(k);
+            // Just verify it doesn't panic
         }
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut cache = TlfuCore::new(100);
+        cache.set(vec![(1, 0), (2, 0), (3, 0)]);
+        assert!(cache.len() > 0);
+
+        cache.clear();
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn test_keys() {
+        let mut cache = TlfuCore::new(100);
+        let entries = vec![(1, 0), (2, 0), (3, 0)];
+        cache.set(entries.clone());
+
+        let mut keys = cache.keys();
+        keys.sort_unstable();
+        assert_eq!(keys, vec![1, 2, 3]);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,264 @@
+use std::fmt;
+
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+
+/// Comprehensive error type for cache operations
+///
+/// This enum represents all error conditions that can occur during cache operations.
+/// Each variant includes context information to aid debugging and monitoring.
+///
+/// # Examples
+///
+/// ```ignore
+/// use theine_core::errors::CacheError;
+///
+/// let err = CacheError::policy(42, "inconsistent state");
+/// eprintln!("{}", err); // Policy error for key 42: inconsistent state
+/// ```
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum CacheError {
+    /// Policy algorithm encountered an inconsistency
+    ///
+    /// This typically indicates a bug in the TinyLFU or SLRU implementation
+    Policy { key: u64, message: String },
+
+    /// Timer wheel expiration system encountered an error
+    TimerWheel { key: u64, message: String },
+
+    /// Cache metadata inconsistency detected
+    ///
+    /// Entry exists but is missing from expected data structures
+    Metadata { key: u64, message: String },
+
+    /// User input validation failed
+    Validation(String),
+
+    /// Internal state corruption detected
+    ///
+    /// This indicates the cache's internal consistency was violated
+    StateCorruption(String),
+}
+
+impl fmt::Display for CacheError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Policy { key, message } => {
+                write!(f, "Policy error for key {}: {}", key, message)
+            }
+            Self::TimerWheel { key, message } => {
+                write!(f, "Timer wheel error for key {}: {}", key, message)
+            }
+            Self::Metadata { key, message } => {
+                write!(f, "Metadata error for key {}: {}", key, message)
+            }
+            Self::Validation(msg) => {
+                write!(f, "Validation error: {}", msg)
+            }
+            Self::StateCorruption(msg) => {
+                write!(f, "State corruption: {}", msg)
+            }
+        }
+    }
+}
+
+impl From<anyhow::Error> for CacheError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::StateCorruption(err.to_string())
+    }
+}
+
+impl std::error::Error for CacheError {}
+
+/// Automatic conversion to Python exceptions with logging
+impl From<CacheError> for PyErr {
+    fn from(err: CacheError) -> Self {
+        let err_msg = err.to_string();
+
+        match &err {
+            CacheError::Policy { .. }
+            | CacheError::TimerWheel { .. }
+            | CacheError::Metadata { .. }
+            | CacheError::StateCorruption(_) => {
+                log::error!("{}", err_msg);
+                PyRuntimeError::new_err(err_msg)
+            }
+            CacheError::Validation(_) => {
+                log::warn!("{}", err_msg);
+                PyValueError::new_err(err_msg)
+            }
+        }
+    }
+}
+
+/// Constructor methods for creating errors with minimal boilerplate
+impl CacheError {
+    /// Create a policy error with context
+    ///
+    /// # Arguments
+    /// * `key` - The cache key involved in the error
+    /// * `message` - A descriptive message about what went wrong
+    #[must_use]
+    pub fn policy(key: u64, message: impl Into<String>) -> Self {
+        Self::Policy {
+            key,
+            message: message.into(),
+        }
+    }
+
+    /// Create a timer wheel error with context
+    ///
+    /// # Arguments
+    /// * `key` - The cache key involved in the error
+    /// * `message` - A descriptive message about what went wrong
+    #[must_use]
+    pub fn timer_wheel(key: u64, message: impl Into<String>) -> Self {
+        Self::TimerWheel {
+            key,
+            message: message.into(),
+        }
+    }
+
+    /// Create a metadata error with context
+    ///
+    /// # Arguments
+    /// * `key` - The cache key involved in the error
+    /// * `message` - A descriptive message about what went wrong
+    #[must_use]
+    pub fn metadata(key: u64, message: impl Into<String>) -> Self {
+        Self::Metadata {
+            key,
+            message: message.into(),
+        }
+    }
+
+    /// Create a validation error
+    ///
+    /// # Arguments
+    /// * `message` - A descriptive validation error message
+    #[must_use]
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::Validation(message.into())
+    }
+
+    /// Create a state corruption error
+    ///
+    /// # Arguments
+    /// * `message` - A descriptive message about the corruption
+    #[must_use]
+    pub fn corruption(message: impl Into<String>) -> Self {
+        Self::StateCorruption(message.into())
+    }
+}
+
+/// Safely execute a closure, catching panics and converting them to PyErr
+///
+/// This function ensures that panics in cache operations are caught and
+/// converted to Python exceptions, preventing crashes in Python code.
+///
+/// # Arguments
+/// * `f` - A closure that might panic
+/// * `operation` - A string describing the operation for error messages
+///
+/// # Returns
+/// * `Ok(T)` if the closure completes successfully
+/// * `Err(PyRuntimeError)` if the closure panics
+///
+/// # Example
+///
+/// ```ignore
+/// let result = catch_panic(|| {
+///     // Risky operation
+///     cache.some_operation()
+/// }, "operation_name")?;
+/// ```
+#[inline]
+pub fn catch_panic<F, T>(f: F, operation: &str) -> PyResult<T>
+where
+    F: FnOnce() -> T + std::panic::UnwindSafe,
+{
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).map_err(|_| {
+        let msg = format!(
+            "Cache operation panicked in {}: this indicates an internal bug",
+            operation
+        );
+        log::error!("{}", msg);
+        PyRuntimeError::new_err(msg)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_policy_error() {
+        let err = CacheError::policy(123, "missing index");
+        assert_eq!(err.to_string(), "Policy error for key 123: missing index");
+    }
+
+    #[test]
+    fn test_display_validation_error() {
+        let err = CacheError::validation("invalid size");
+        assert_eq!(err.to_string(), "Validation error: invalid size");
+    }
+
+    #[test]
+    fn test_display_corruption_error() {
+        let err = CacheError::corruption("state inconsistency");
+        assert_eq!(err.to_string(), "State corruption: state inconsistency");
+    }
+
+    #[test]
+    fn test_builder_methods() {
+        assert!(matches!(
+            CacheError::policy(1, "test"),
+            CacheError::Policy { .. }
+        ));
+        assert!(matches!(
+            CacheError::validation("test"),
+            CacheError::Validation(_)
+        ));
+        assert!(matches!(
+            CacheError::corruption("test"),
+            CacheError::StateCorruption(_)
+        ));
+    }
+
+    #[test]
+    fn test_error_to_pyerr_validation() {
+        Python::attach(|py| {
+            let err: CacheError = CacheError::validation("test");
+            let py_err: PyErr = err.into();
+            assert!(py_err.is_instance_of::<PyValueError>(py));
+        });
+    }
+
+    #[test]
+    fn test_error_to_pyerr_policy() {
+        Python::attach(|py| {
+            let err: CacheError = CacheError::policy(42, "test");
+            let py_err: PyErr = err.into();
+            assert!(py_err.is_instance_of::<PyRuntimeError>(py));
+        });
+    }
+
+    #[test]
+    fn test_catch_panic_success() {
+        let result = catch_panic(|| 42, "test");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_catch_panic_on_panic() {
+        let result = catch_panic(
+            || {
+                panic!("test panic");
+            },
+            "failing_operation",
+        );
+        assert!(result.is_err());
+    }
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -13,16 +13,33 @@ pub struct BloomFilter {
 impl BloomFilter {
     #[new]
     fn new(insertions: usize, fpp: f64) -> Self {
+        // Input validation
+        let insertions = if insertions == 0 { 1 } else { insertions };
+
+        // Clamp FPP to valid range [0.001, 0.999]
+        let fpp = fpp.max(0.001).min(0.999);
+
         let ln2 = 2f64.ln();
         let factor = -fpp.ln() / (ln2 * ln2);
         let mut bits = ((insertions as f64 * factor) as usize).next_power_of_two();
         if bits == 0 {
             bits = 1
         }
+
+        let slice_count = ((ln2 * bits as f64 / insertions as f64) as usize).max(1);
+
+        log::debug!(
+            "BloomFilter created: insertions={}, fpp={}, bits={}, slice_count={}",
+            insertions,
+            fpp,
+            bits,
+            slice_count
+        );
+
         Self {
             insertions,
             bits_mask: bits - 1,
-            slice_count: (ln2 * bits as f64 / insertions as f64) as usize,
+            slice_count,
             bits: vec![0; bits.div_ceil(64)],
             additions: 0,
         }
@@ -30,47 +47,93 @@ impl BloomFilter {
 
     pub fn put(&mut self, key: u64) {
         self.additions += 1;
-        if self.additions == self.insertions {
+        if self.additions >= self.insertions {
             self.reset();
         }
+
         for i in 0..self.slice_count {
-            let hash = key + (i as u64) * (key >> 32);
-            self.set(hash & self.bits_mask as u64);
+            // Use wrapping arithmetic to prevent overflow
+            let hash = key.wrapping_add((i as u64).wrapping_mul(key >> 32));
+            let hash_index = (hash & self.bits_mask as u64) as usize;
+            self.set(hash_index);
         }
     }
 
-    fn get(&self, key: u64) -> bool {
+    fn get(&self, key: usize) -> bool {
+        // Bounds checking
+        if key >= self.bits.len() * 64 {
+            log::warn!("BloomFilter get: key {} out of bounds", key);
+            return false;
+        }
+
         let idx = key >> 6;
         let offset = key & 63;
         let mask = 1u64 << offset;
-        let val = self.bits[idx as usize];
+
+        if idx >= self.bits.len() {
+            return false;
+        }
+
+        let val = self.bits[idx];
         ((val & mask) >> offset) != 0
     }
 
-    fn set(&mut self, key: u64) {
+    fn set(&mut self, key: usize) {
+        // Bounds checking
+        if key >= self.bits.len() * 64 {
+            log::warn!("BloomFilter set: key {} out of bounds", key);
+            return;
+        }
+
         let idx = key >> 6;
         let offset = key & 63;
+
+        if idx >= self.bits.len() {
+            log::warn!(
+                "BloomFilter set: computed idx {} exceeds bits length {}",
+                idx,
+                self.bits.len()
+            );
+            return;
+        }
+
         let mask = 1u64 << offset;
-        self.bits[idx as usize] |= mask;
+        self.bits[idx] |= mask;
     }
 
     pub fn contains(&self, key: u64) -> bool {
-        let mut o = true;
-        for i in 0..self.slice_count {
-            let hash = key + i as u64 * (key >> 32);
-            o &= self.get(hash & self.bits_mask as u64);
+        // Early exit if no hashes configured
+        if self.slice_count == 0 {
+            log::warn!(
+                "BloomFilter contains: slice_count is 0, this indicates a configuration error"
+            );
+            return false;
         }
-        o
+
+        let mut result = true;
+        for i in 0..self.slice_count {
+            // Use wrapping arithmetic to safely handle overflows
+            let hash = key.wrapping_add((i as u64).wrapping_mul(key >> 32));
+            let hash_index = (hash & self.bits_mask as u64) as usize;
+
+            if !self.get(hash_index) {
+                result = false;
+                break;
+            }
+        }
+        result
     }
 
     fn reset(&mut self) {
         self.bits = vec![0; self.bits.len()];
         self.additions = 0;
+        log::debug!("BloomFilter reset: cleared all bits");
     }
 }
 
 #[cfg(test)]
 mod tests {
+
     use super::BloomFilter;
 
     #[test]
@@ -94,5 +157,40 @@ mod tests {
             let exist = bf.contains(i);
             assert!(exist);
         }
+    }
+
+    #[test]
+    fn test_filter_edge_cases() {
+        // Test with zero insertions
+        let mut bf = BloomFilter::new(0, 0.001);
+        assert!(bf.insertions > 0);
+        bf.put(1);
+
+        // Test with invalid FPP
+        let mut bf = BloomFilter::new(100, 0.0);
+        bf.put(1);
+
+        let mut bf = BloomFilter::new(100, 1.5);
+        bf.put(1);
+
+        // Test with large keys
+        let mut bf = BloomFilter::new(100, 0.001);
+        bf.put(u64::MAX);
+        assert!(bf.contains(u64::MAX));
+    }
+
+    #[test]
+    fn test_filter_bounds() {
+        let mut bf = BloomFilter::new(100, 0.001);
+
+        // These should not panic
+        let _ = bf.contains(0);
+        let _ = bf.contains(u64::MAX);
+
+        bf.put(0);
+        bf.put(u64::MAX);
+
+        assert!(bf.contains(0));
+        assert!(bf.contains(u64::MAX));
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -23,7 +23,7 @@ impl BloomFilter {
             insertions,
             bits_mask: bits - 1,
             slice_count: (ln2 * bits as f64 / insertions as f64) as usize,
-            bits: vec![0; (bits + 63) / 64],
+            bits: vec![0; bits.div_ceil(64)],
             additions: 0,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
+
 mod core;
 mod filter;
 mod lru;
@@ -10,6 +11,11 @@ mod tlfu;
 
 #[pymodule(gil_used = false)]
 fn theine_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Initialize logging using the log crate
+    // Python can intercept these logs via the logging module's integration with rust logs
+    // Users can configure Python's logging to see theine_core messages
+    let _ = log::logger();
+
     m.add_class::<core::TlfuCore>()?;
     m.add_class::<filter::BloomFilter>()?;
     m.add_function(wrap_pyfunction!(core::spread, m)?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
 mod core;
+mod errors;
 mod filter;
 mod lru;
 mod metadata;

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -1,145 +1,265 @@
+//! Least Recently Used (LRU) eviction policy.
+//!
+//! A simple policy that evicts the least recently accessed entries first.
+
 use crate::metadata::{Entry, List};
 use anyhow::Result;
 use dlv_list::Index;
 use std::collections::HashMap;
 
+/// Least Recently Used cache policy implementation.
+///
+/// This policy maintains a doubly-linked list where newly accessed items
+/// are moved to the front, and eviction always removes from the back.
+///
+/// # Note
+///
+/// Policy list ID for LRU entries is `1`.
+#[derive(Debug)]
 pub struct Lru {
-    pub list: List<u64>, // id is 1
+    pub list: List<u64>,
 }
 
 impl Lru {
-    pub fn new(maxsize: usize) -> Lru {
-        let maxsize = if maxsize == 0 { 1 } else { maxsize };
+    /// Creates a new LRU policy with the specified capacity.
+    ///
+    /// # Arguments
+    ///
+    /// * `maxsize` - Maximum number of entries. Defaults to 1 if 0.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let lru = Lru::new(1000);
+    /// ```
+    pub fn new(maxsize: usize) -> Self {
+        let maxsize = maxsize.max(1);
         log::debug!("LRU created with maxsize={}", maxsize);
-        Lru {
+        Self {
             list: List::new(maxsize),
         }
     }
 
+    /// Inserts a new key into the LRU list at the front.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The cache key to insert
+    /// * `entry` - The entry metadata to update with position information
     pub fn insert(&mut self, key: u64, entry: &mut Entry) {
         let index = self.list.insert_front(key);
         entry.policy_list_index = Some(index);
         entry.policy_list_id = 1;
     }
 
+    /// Marks an entry as accessed by moving it to the front of the list.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - The current position of the entry in the list
+    #[inline]
     pub fn access(&mut self, index: Index<u64>) {
-        self.list.touch(index)
+        self.list.touch(index);
     }
 
+    /// Returns the current number of entries in the list.
+    #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.list.len()
     }
 
+    /// Removes an entry from the LRU list.
+    ///
+    /// # Arguments
+    ///
+    /// * `entry` - The entry to remove
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if removal succeeded, `Err` if the entry's position was missing
     pub fn remove(&mut self, entry: &Entry) -> Result<()> {
-        if let Some(index) = entry.policy_list_index {
-            self.list.remove(index);
-            Ok(())
-        } else {
-            let err = anyhow::anyhow!(
-                "LRU remove: missing policy_list_index for entry, this indicates a bug"
-            );
-            log::error!("{}", err);
-            Err(err)
-        }
+        entry
+            .policy_list_index
+            .ok_or_else(|| {
+                let err = anyhow::anyhow!(
+                    "LRU remove: missing policy_list_index for entry, this indicates a bug"
+                );
+                log::error!("{}", err);
+                err
+            })
+            .map(|index| self.list.remove(index))
     }
 }
 
+/// Segmented Least Recently Used cache policy.
+///
+/// This policy maintains two lists: probation (80% of capacity) and protected (20% remainder).
+/// New entries start in probation, and are promoted to protected on second access.
+/// This provides better scan resistance than simple LRU.
+///
+/// # Policy List IDs
+///
+/// - `2`: Probation list (80% capacity)
+/// - `3`: Protected list (20% capacity)
+#[derive(Debug)]
 pub struct Slru {
     pub probation: List<u64>,
     pub protected: List<u64>,
 }
 
 impl Slru {
-    pub fn new(maxsize: usize) -> Slru {
-        let maxsize = if maxsize == 0 { 1 } else { maxsize };
+    /// Creates a new SLRU policy with 80/20 split between probation and protected.
+    ///
+    /// # Arguments
+    ///
+    /// * `maxsize` - Total capacity. Defaults to 1 if 0.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let slru = Slru::new(1000); // 800 probation, 200 protected
+    /// ```
+    pub fn new(maxsize: usize) -> Self {
+        let maxsize = maxsize.max(1);
         let protected_cap = (maxsize as f64 * 0.8) as usize;
         log::debug!(
             "SLRU created with maxsize={}, protected_cap={}",
             maxsize,
             protected_cap
         );
-        Slru {
+        Self {
             probation: List::new(maxsize),
             protected: List::new(protected_cap),
         }
     }
 
+    /// Inserts a new key into the probation list.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The cache key to insert
+    /// * `entry` - The entry metadata to update with position information
     pub fn insert(&mut self, key: u64, entry: &mut Entry) {
         let index = self.probation.insert_front(key);
         entry.policy_list_index = Some(index);
         entry.policy_list_id = 2;
     }
 
+    /// Updates policy state when an entry is accessed.
+    ///
+    /// If in probation (first access), promotes to protected.
+    /// If in protected (subsequent accesses), marks as recently used.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The cache key being accessed
+    /// * `entries` - Mutable reference to the cache entries map
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if access succeeded, `Err` if entry state is invalid
     pub fn access(&mut self, key: u64, entries: &mut HashMap<u64, Entry>) -> Result<()> {
-        if let Some(entry) = entries.get_mut(&key) {
-            match entry.policy_list_id {
-                2 => {
-                    if let Some(index) = entry.policy_list_index {
-                        self.probation.remove(index);
-                        let new_index = self.protected.insert_front(key);
-                        entry.policy_list_index = Some(new_index);
-                        entry.policy_list_id = 3;
-                        Ok(())
-                    } else {
-                        let err = anyhow::anyhow!(
-                            "SLRU access: missing policy_list_index for probation entry {}, this indicates a bug",
-                            key
-                        );
-                        log::error!("{}", err);
-                        Err(err)
-                    }
-                }
-                3 => {
-                    if let Some(index) = entry.policy_list_index {
-                        self.protected.touch(index);
-                        Ok(())
-                    } else {
-                        let err = anyhow::anyhow!(
-                            "SLRU access: missing policy_list_index for protected entry {}, this indicates a bug",
-                            key
-                        );
-                        log::error!("{}", err);
-                        Err(err)
-                    }
-                }
-                _ => {
-                    let err = anyhow::anyhow!(
-                        "SLRU access: unexpected policy_list_id {} for entry {}, this indicates a bug",
-                        entry.policy_list_id,
-                        key
-                    );
-                    log::error!("{}", err);
-                    Err(err)
-                }
+        entries
+            .get_mut(&key)
+            .ok_or_else(|| {
+                // Entry not found is not an error in this context
+                anyhow::anyhow!("Entry not found during access")
+            })
+            .and_then(|entry| self.handle_access(entry, key))
+    }
+
+    /// Internal helper to handle access for a specific entry.
+    fn handle_access(&mut self, entry: &mut Entry, key: u64) -> Result<()> {
+        match entry.policy_list_id {
+            2 => self.promote_from_probation(entry, key),
+            3 => self.touch_in_protected(entry),
+            list_id => {
+                let err = anyhow::anyhow!(
+                    "SLRU access: unexpected policy_list_id {} for entry {}, this indicates a bug",
+                    list_id,
+                    key
+                );
+                log::error!("{}", err);
+                Err(err)
             }
-        } else {
-            // Entry not found is not an error in this context
-            Ok(())
         }
     }
 
+    /// Promotes an entry from probation to protected list.
+    fn promote_from_probation(&mut self, entry: &mut Entry, key: u64) -> Result<()> {
+        entry
+            .policy_list_index
+            .ok_or_else(|| {
+                let err = anyhow::anyhow!(
+                    "SLRU access: missing policy_list_index for probation entry {}, this indicates a bug",
+                    key
+                );
+                log::error!("{}", err);
+                err
+            })
+            .map(|index| {
+                self.probation.remove(index);
+                let new_index = self.protected.insert_front(key);
+                entry.policy_list_index = Some(new_index);
+                entry.policy_list_id = 3;
+            })
+    }
+
+    /// Marks an entry in protected list as recently used.
+    fn touch_in_protected(&mut self, entry: &mut Entry) -> Result<()> {
+        entry
+            .policy_list_index
+            .ok_or_else(|| {
+                let err = anyhow::anyhow!(
+                    "SLRU access: missing policy_list_index for protected entry, this indicates a bug"
+                );
+                log::error!("{}", err);
+                err
+            })
+            .map(|index| {
+                self.protected.touch(index);
+            })
+    }
+
+    /// Removes an entry from either the probation or protected list.
+    ///
+    /// # Arguments
+    ///
+    /// * `entry` - The entry to remove
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` if removal succeeded, `Err` if entry state is invalid
     pub fn remove(&mut self, entry: &Entry) -> Result<()> {
-        if let Some(list_index) = entry.policy_list_index {
-            match entry.policy_list_id {
-                2 => self.probation.remove(list_index),
-                3 => self.protected.remove(list_index),
-                _ => {
-                    let err = anyhow::anyhow!(
-                        "SLRU remove: unexpected policy_list_id {}, this indicates a bug",
-                        entry.policy_list_id
-                    );
-                    log::error!("{}", err);
-                    return Err(err);
-                }
-            };
-            Ok(())
-        } else {
-            let err = anyhow::anyhow!(
-                "SLRU remove: missing policy_list_index for entry with policy_list_id {}, this indicates a bug",
-                entry.policy_list_id
-            );
-            log::error!("{}", err);
-            Err(err)
+        let list_index = entry
+            .policy_list_index
+            .ok_or_else(|| {
+                let err = anyhow::anyhow!(
+                    "SLRU remove: missing policy_list_index for entry with policy_list_id {}, this indicates a bug",
+                    entry.policy_list_id
+                );
+                log::error!("{}", err);
+                err
+            })?;
+
+        match entry.policy_list_id {
+            2 => {
+                self.probation.remove(list_index);
+                Ok(())
+            }
+            3 => {
+                self.protected.remove(list_index);
+                Ok(())
+            }
+            list_id => {
+                let err = anyhow::anyhow!(
+                    "SLRU remove: unexpected policy_list_id {}, this indicates a bug",
+                    list_id
+                );
+                log::error!("{}", err);
+                Err(err)
+            }
         }
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,5 +1,15 @@
 use dlv_list::{Index, Iter, VecList};
+use log;
 
+/// Entry represents a cached item with metadata about its position in various data structures.
+///
+/// Fields:
+/// - policy_list_id: Which list the entry belongs to (0=not in policy, 1=window/lru, 2=probation, 3=protected)
+/// - policy_list_index: Position in the policy list (window, probation, or protected)
+/// - wheel_list_index: Position in the timer wheel for TTL expiration
+/// - wheel_index: Which bucket in the timer wheel (level, slot)
+/// - expire: Expiration time in nanoseconds (0 = no expiration)
+#[derive(Debug, Clone)]
 pub struct Entry {
     pub policy_list_id: u8,
     pub policy_list_index: Option<Index<u64>>,
@@ -24,6 +34,54 @@ impl Entry {
             policy_list_id: 0,
         }
     }
+
+    /// Validate that the entry's metadata is consistent
+    pub fn validate(&self) -> Result<(), String> {
+        // Policy list ID must be in valid range [0-3]
+        if self.policy_list_id > 3 {
+            return Err(format!(
+                "Invalid policy_list_id: {}, must be in range [0-3]",
+                self.policy_list_id
+            ));
+        }
+
+        // If policy_list_id is 0, indices should be None
+        if self.policy_list_id == 0 {
+            if self.policy_list_index.is_some() {
+                return Err(
+                    "Entry with policy_list_id=0 should not have policy_list_index set".to_string(),
+                );
+            }
+        } else {
+            // If policy_list_id is 1-3, index should be Some
+            if self.policy_list_index.is_none() {
+                return Err(format!(
+                    "Entry with policy_list_id={} should have policy_list_index set",
+                    self.policy_list_id
+                ));
+            }
+        }
+
+        // Timer wheel indices should be valid ranges
+        if self.wheel_index.0 > 4 {
+            return Err(format!(
+                "Invalid wheel level: {}, must be in range [0-4]",
+                self.wheel_index.0
+            ));
+        }
+
+        // If expire is set, wheel_list_index should be Some
+        if self.expire > 0 && self.wheel_list_index.is_none() {
+            return Err("Entry with expire time should have wheel_list_index set".to_string());
+        }
+
+        Ok(())
+    }
+
+    /// Check if entry is expired given current time
+    pub fn is_expired(&self, now_ns: u64) -> bool {
+        self.expire > 0 && self.expire <= now_ns
+    }
 }
 
 #[derive(Debug)]
@@ -34,6 +92,8 @@ pub struct List<T> {
 
 impl<T> List<T> {
     pub fn new(capacity: usize) -> Self {
+        let capacity = if capacity == 0 { 1 } else { capacity };
+        log::debug!("List created with capacity={}", capacity);
         Self {
             capacity,
             list: VecList::with_capacity(capacity),
@@ -41,17 +101,21 @@ impl<T> List<T> {
     }
 
     /// Remove entry at index from list
+    ///
+    /// # Note
+    /// This operation is safe - dlv_list handles invalid indices gracefully
     pub fn remove(&mut self, index: Index<T>) {
         self.list.remove(index);
     }
 
-    /// Insert entry to list front and return evicted key
+    /// Insert entry to list front and return its index
+    ///
+    /// Maintains the invariant that newly inserted items are at the front
     pub fn insert_front(&mut self, entry: T) -> Index<T> {
         if let Some(index) = self.list.front_index() {
             self.list.insert_before(index, entry)
         } else {
-            // no frony entry, list is empty
-
+            // no front entry, list is empty
             self.list.push_front(entry)
         }
     }
@@ -75,7 +139,9 @@ impl<T> List<T> {
         self.list.pop_back()
     }
 
-    /// Move entry to front of link
+    /// Move entry to front of list
+    ///
+    /// Only moves if the entry is not already at front to avoid unnecessary operations
     pub fn touch(&mut self, index: Index<T>) {
         if let Some(front) = self.list.front_index()
             && front != index
@@ -84,16 +150,25 @@ impl<T> List<T> {
         }
     }
 
+    /// Iterate over list entries
     pub fn iter(&self) -> Iter<'_, T> {
         self.list.iter()
     }
 
+    /// Get current number of entries in list
     pub fn len(&self) -> usize {
         self.list.len()
     }
 
-    /// Clear list
+    /// Check if list is empty
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.list.is_empty()
+    }
+
+    /// Clear all entries from the list
     pub fn clear(&mut self) {
-        self.list.clear()
+        self.list.clear();
+        log::debug!("List cleared");
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -77,10 +77,10 @@ impl<T> List<T> {
 
     /// Move entry to front of link
     pub fn touch(&mut self, index: Index<T>) {
-        if let Some(front) = self.list.front_index() {
-            if front != index {
-                self.list.move_before(index, front);
-            }
+        if let Some(front) = self.list.front_index()
+            && front != index
+        {
+            self.list.move_before(index, front);
         }
     }
 

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -90,9 +90,8 @@ impl CountMinSketch {
         let count1 = self.count(counter_hash, block, 1);
         let count2 = self.count(counter_hash, block, 2);
         let count3 = self.count(counter_hash, block, 3);
-        let s = [count0, count1, count2, count3];
-        let min = s.iter().min().unwrap();
-        *min
+        // Calculate minimum directly without iterator allocation
+        count0.min(count1).min(count2).min(count3)
     }
 
     #[cfg(test)]
@@ -219,8 +218,8 @@ mod tests {
 
             let es1 = sketch.estimate(h);
             let es2 = sketch.estimate(h2);
-            let es1_prev = *counts.get(&h).unwrap();
-            let es2_prev = *counts.get(&h2).unwrap();
+            let es1_prev = counts.get(&h).copied().unwrap_or(0);
+            let es2_prev = counts.get(&h2).copied().unwrap_or(0);
             diff += es1_prev - es1;
             diff += es2_prev - es2;
 

--- a/src/timerwheel.rs
+++ b/src/timerwheel.rs
@@ -29,11 +29,7 @@ impl Clock {
     }
 
     pub fn expire_ns(&self, ttl: u64) -> u64 {
-        if ttl > 0 {
-            self.now_ns() + ttl
-        } else {
-            0
-        }
+        if ttl > 0 { self.now_ns() + ttl } else { 0 }
     }
 }
 
@@ -368,10 +364,10 @@ mod tests {
     fn test_advance_large() {
         let mut core = TlfuCore::new(1000);
         let now = core.wheel.clock.now_ns();
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for _ in 0..50000 {
-            let expire = now + Duration::from_secs(rng.gen_range(5..250)).as_nanos() as u64;
-            core.set(vec![(rng.gen_range(0..10000), expire as i64)]);
+            let expire = now + Duration::from_secs(rng.random_range(5..250)).as_nanos() as u64;
+            core.set(vec![(rng.random_range(0..10000), expire as i64)]);
         }
 
         for dt in [5, 6, 7, 10, 15, 20, 25, 50, 51, 52, 53, 70, 75, 85, 100] {
@@ -383,8 +379,8 @@ mod tests {
 
         let now = core.wheel.clock.now_ns();
         for _ in 0..10000 {
-            let expire = now + Duration::from_secs(rng.gen_range(110..250)).as_nanos() as u64;
-            core.set(vec![(rng.gen_range(0..1000), expire as i64)]);
+            let expire = now + Duration::from_secs(rng.random_range(110..250)).as_nanos() as u64;
+            core.set(vec![(rng.random_range(0..1000), expire as i64)]);
         }
         for dt in [5, 6, 7, 10, 15, 20, 25, 50, 51, 52, 53, 70, 75, 85, 100] {
             core.wheel.advance(

--- a/src/tlfu.rs
+++ b/src/tlfu.rs
@@ -4,7 +4,7 @@ use crate::metadata::Entry;
 use crate::sketch::CountMinSketch;
 use crate::timerwheel::Clock;
 use anyhow::Result;
-use log;
+
 use pyo3::prelude::pyclass;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -716,7 +716,7 @@ mod tests {
             }
 
             for i in 0..80 {
-                if let Err(_) = tlfu.access(i, &clock, &mut entries) {
+                if tlfu.access(i, &clock, &mut entries).is_err() {
                     // Test access error - continue with other accesses
                 }
             }
@@ -727,7 +727,7 @@ mod tests {
                 tlfu.hit_in_sample = new_hits;
                 tlfu.misses_in_sample = new_misses;
                 tlfu.climb();
-                if let Err(_) = tlfu.resize_window(&mut entries) {
+                if tlfu.resize_window(&mut entries).is_err() {
                     // In tests, resize_window errors indicate bugs in the test setup
                     // but we continue to test the overall behavior
                 }
@@ -749,18 +749,12 @@ mod tests {
         let mut entries = HashMap::new();
 
         for i in 0..200 {
-            let evicted = match tlfu.set(i, &mut entries) {
-                Ok(evicted) => evicted,
-                Err(_) => None, // Test continues even if set fails
-            };
+            let evicted = tlfu.set(i, &mut entries).unwrap_or_default();
             assert!(evicted.is_none());
         }
 
         for i in 0..200 {
-            let evicted = match tlfu.set(i, &mut entries) {
-                Ok(evicted) => evicted,
-                Err(_) => None, // Test continues even if set fails
-            };
+            let evicted = tlfu.set(i, &mut entries).unwrap_or_default();
             assert!(evicted.is_none());
         }
     }


### PR DESCRIPTION
Recently I ran into multiple panics due to unwrap not being able to
return a value.

In order to fix the `exception=PanicException('called `Option::unwrap()`
on a `None` value')>`, all unwraps have been transformed to either unwrap
or default to return either None or the value itself, which is
considered a best practice.